### PR TITLE
Existing haskell_rules with the name that would be generated are considered enclosed

### DIFF
--- a/example/package-a/BUILD.bazel
+++ b/example/package-a/BUILD.bazel
@@ -92,6 +92,12 @@ haskell_library(
 )
 
 haskell_module(
+    name = "another-haskell-binary.Main",
+    src = "app/AnotherMain.hs",
+    extra_srcs = glob(["app/**"]),
+)
+
+haskell_module(
     name = "non-enclosed-module",
     src = "app/Main.hs",
 )

--- a/gazelle_haskell_modules/rule_generation.go
+++ b/gazelle_haskell_modules/rule_generation.go
@@ -62,23 +62,30 @@ func nonHaskellModuleRulesToRuleInfos(
 				OriginatingRules: []*rule.Rule{r},
 				ModuleData: modData,
 			}
-			moduleLabels[label.New(repo, pkg, ruleNameFromRuleInfo(ruleInfos[i]))] = true
+			modLabel := label.New(repo, pkg, ruleNameFromRuleInfo(ruleInfos[i]))
+			addOriginatingRule(originatingRules, &modLabel, r)
+			moduleLabels[modLabel] = true
 		}
 		ruleInfoss = append(ruleInfoss, ruleInfos)
 
 		for mod, _ := range modules {
-			oRules := originatingRules[mod]
-			if oRules == nil {
-				originatingRules[mod] = []*rule.Rule{r}
-			} else {
-				originatingRules[mod] = append(oRules, r)
-			}
+			addOriginatingRule(originatingRules, &mod, r)
 			moduleLabels[mod] = true
 		}
 
 		r.SetPrivateAttr(PRIVATE_ATTR_MODULE_LABELS, moduleLabels)
 	}
 	return ruleInfoss, originatingRules
+}
+
+// Adds a rule to a map at the given label.
+func addOriginatingRule(originatingRules map[label.Label][]*rule.Rule, mod *label.Label, r *rule.Rule) {
+	oRules := originatingRules[*mod]
+	if oRules == nil {
+		originatingRules[*mod] = []*rule.Rule{r}
+	} else {
+		originatingRules[*mod] = append(oRules, r)
+	}
 }
 
 // originatingRules is used to determine which rule is originating a haskell_module


### PR DESCRIPTION
Before this change we would get a failure when running gazelle, complaining that the source file of the module in question isn't indexed.