### PR TITLE
Add support for parsing post qualified imports.

### DIFF
--- a/himportscan/src/HImportScan/ImportScanner.hs
+++ b/himportscan/src/HImportScan/ImportScanner.hs
@@ -174,6 +174,7 @@ scanTokenStream fp toks =
       _ -> Nothing
 
     parseImportTail = do
+      optional $ satisfy "qualified" $ \case ITqualified -> Just (); _ -> Nothing
       optional $ do
         satisfy "as" $ \case ITas -> Just (); _ -> Nothing
         parseModuleName

--- a/himportscan/tests/HImportScan/ImportScannerSpec.hs
+++ b/himportscan/tests/HImportScan/ImportScannerSpec.hs
@@ -79,6 +79,14 @@ spec_scanImports = do
          import A.B.C
          import A.B.D
       |]
+    it "should accept post fix qualified imports" $
+      testSource "M" [m "A.B.C", m "A.B.D", m "A.B.E"] False [s|
+         module M where
+
+         import A.B.C
+         import A.B.D qualified
+         import A.B.E
+        |]
     it "should accept package imports" $
       testSource
         "M"


### PR DESCRIPTION
`himportscan` is unable to parse imports of the form

```haskell
import PackageA qualified
import PackageB
````

As soon as it hits the `qualified` token, it ignores the rest of the imports in the module. I fixed this by always choosing to optionally parse `qualified` in post position irrespective of the presence of the extension.