### PR TITLE
Keep not-found hidden_modules

### DIFF
--- a/gazelle_haskell_modules/lang.go
+++ b/gazelle_haskell_modules/lang.go
@@ -241,6 +241,12 @@ func cleanupModulesList(r *rule.Rule, deleted map[string]bool) {
 	cleanupModulesLists(r, "modules", shouldKeepModule)
 }
 
+// Removes from the hidden_modules attribute the modules in the map deleted
+// which are also mentioned in the modules attribute.
+//
+// This function depends on haskell_module rule names following the
+// convention <libname>.<modulename>, where <modulename> is the name
+// of the module that is/was defined by the rule.
 func cleanupHiddenModulesList(r *rule.Rule, deleted map[string]bool) {
 	ruleName := r.Name()
 	modules := r.AttrStrings("modules")

--- a/gazelle_haskell_modules/rule_generation.go
+++ b/gazelle_haskell_modules/rule_generation.go
@@ -50,7 +50,7 @@ func nonHaskellModuleRulesToRuleInfos(
 	originatingRules := make(map[label.Label][]*rule.Rule, 100)
 	// Analyze non-haskell_module rules
 	for _, r := range rules {
-		if !isNonHaskellModule(r.Kind()) || !shouldModularize(r) {
+		if !isNonHaskellModule(r.Kind()) || !shouldKeep(r) {
 			continue
 		}
 		srcs, err := getSrcs(pkgRoot, r)
@@ -208,7 +208,7 @@ func addNonHaskellModuleRules(
 	haskellRules := make([]*rule.Rule, 0, len(rules))
 	imports := make([]interface{}, 0, len(rules))
 	for _, r := range rules {
-		if !shouldModularize(r) {
+		if !shouldKeep(r) {
 			continue
 		}
 		if isNonHaskellModule(r.Kind()) {
@@ -514,7 +514,8 @@ func ruleNameFromRuleInfo(ruleInfo *RuleInfo) string {
 	return ruleInfo.OriginatingRules[0].Name() + "." + ruleInfo.ModuleData.ModuleName
 }
 
-func shouldModularize(r *rule.Rule) bool {
+// Check for the "usual" keep directive, along with our own custom "# gazelle_haskell_modules:keep".
+func shouldKeep(r *rule.Rule) bool {
 	if r.ShouldKeep() {
 		return false
 	}


### PR DESCRIPTION
We now only delete hidden_modules if we explicitly have deleted them from the current build file, instead of deleting them whenever they're not found.

Not sure how to test this without introducing some machinery to inspect build files. Ideas?

Fixes #27