### PR TITLE
Handle several GHC versions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,19 @@
+build:ghc_9_0_2 --repo_env=GHC_VERSION=9.0.2
+fetch:ghc_9_0_2 --repo_env=GHC_VERSION=9.0.2
+query:ghc_9_0_2 --repo_env=GHC_VERSION=9.0.2
+sync:ghc_9_0_2 --repo_env=GHC_VERSION=9.0.2
+run:ghc_9_0_2 --repo_env=GHC_VERSION=9.0.2
+
+build:ghc_9_2_2 --repo_env=GHC_VERSION=9.2.2
+fetch:ghc_9_2_2 --repo_env=GHC_VERSION=9.2.2
+query:ghc_9_2_2 --repo_env=GHC_VERSION=9.2.2
+sync:ghc_9_2_2 --repo_env=GHC_VERSION=9.2.2
+run:ghc_9_2_2 --repo_env=GHC_VERSION=9.2.2
+
+build:ghc_8_10_7 --repo_env=GHC_VERSION=8.10.7
+fetch:ghc_8_10_7 --repo_env=GHC_VERSION=8.10.7
+query:ghc_8_10_7 --repo_env=GHC_VERSION=8.10.7
+sync:ghc_8_10_7 --repo_env=GHC_VERSION=8.10.7
+run:ghc_8_10_7 --repo_env=GHC_VERSION=8.10.7
+
 try-import .bazelrc.local

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -11,6 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        ghc-version: ["ghc_8_10_7", "ghc_9_0_2", "ghc_9_2_2"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -39,14 +40,14 @@ jobs:
           ln -s ../.bazelrc.local example/.bazelrc.local
           ln -s ../../.bazelrc.local tests/alternative-deps/.bazelrc.local
       - name: Build & test himportscan
-        run: nix-shell --pure --run 'bazel test //himportscan:tasty'
+        run: nix-shell --pure --run 'bazel test //himportscan:tasty --config=${{ matrix.ghc-version }}'
       - name: Build & run gazelle
-        run: cd example; nix-shell --pure --run 'bazel run //:gazelle'
+        run: cd example; nix-shell --pure --run 'bazel run //:gazelle --config=${{ matrix.ghc-version }}'
       - name: Build & run gazelle fix
-        run: cd example; nix-shell --pure --run 'bazel run //:gazelle -- fix'
+        run: cd example; nix-shell --pure --run 'bazel run //:gazelle --config=${{ matrix.ghc-version }} -- fix'
       - name: Build & test generated rules
-        run: cd example; nix-shell --pure --run 'bazel test //...'
+        run: cd example; nix-shell --pure --run 'bazel test //... --config=${{ matrix.ghc-version }}'
       - name: Build & run gazelle with alternative dependencies
-        run: cd tests/alternative-deps; nix-shell --pure --run 'bazel run //:gazelle'
+        run: cd tests/alternative-deps; nix-shell --pure --run 'bazel run //:gazelle --config=${{ matrix.ghc-version }}'
       - name: Test for buildifier suggestions
         run: nix-shell --pure --run 'bazel run //:buildifier-diff'

--- a/config_settings/setup.bzl
+++ b/config_settings/setup.bzl
@@ -1,0 +1,18 @@
+def _config_settings_impl(repository_ctx):
+    ghc_version = repository_ctx.os.environ.get("GHC_VERSION", default = "8.10.7")
+    repository_ctx.file(
+        "BUILD",
+        content = """exports_files(["info.bzl"])""",
+        executable = False,
+    )
+    repository_ctx.file(
+        "info.bzl",
+        content = 'ghc_version = "{}"'.format(ghc_version),
+        executable = False,
+    )
+
+config_settings = repository_rule(
+    implementation = _config_settings_impl,
+    attrs = {},
+    environ = ["GHC_VERSION"],
+)

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -13,9 +13,9 @@ local_repository(
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "c3c85b886a64010c913a7700b0594dbd4204170b1ec00d1afb5f411868e7c54b",
-    strip_prefix = "rules_haskell-af979957c18e11693d4daba606143a7a362af4b1",
-    urls = ["https://github.com/tweag/rules_haskell/archive/af979957c18e11693d4daba606143a7a362af4b1.zip"],
+    sha256 = "57e55ca74c9dd2710da852c6c9a70fc0274f038ff37216b6c48fd9389bbfbce7",
+    strip_prefix = "rules_haskell-b8ac6c18d26c0011a2464200762e45302a70bbf6",
+    urls = ["https://github.com/tweag/rules_haskell/archive/b8ac6c18d26c0011a2464200762e45302a70bbf6.zip"],
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
@@ -41,19 +41,40 @@ load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 # Haskell dependencies and toolchain
 ######################################
 
+load("@io_tweag_gazelle_haskell_modules//:config_settings/setup.bzl", "config_settings")
+
+config_settings(name = "config_settings")
+
+load("@config_settings//:info.bzl", "ghc_version")
 load("@io_tweag_gazelle_haskell_modules//:defs.bzl", "gazelle_haskell_modules_dependencies")
 
 gazelle_haskell_modules_dependencies()
 
 stack_snapshot(
     name = "stackage",
-    components = {
-        "tasty-discover": [
-            "lib",
-            "exe:tasty-discover",
-        ],
-    },
+    components =
+        {
+            "tasty-discover": [
+                "lib",
+                "exe:tasty-discover",
+            ],
+        } if ghc_version == "8.10.7" else {
+            "tasty-discover": [
+                "lib",
+                "exe:tasty-discover",
+            ],
+            "attoparsec": [
+                "lib",
+                "lib:attoparsec-internal",
+            ],
+        },
+    components_dependencies =
+        None if ghc_version == "8.10.7" else {
+            "attoparsec": """{"lib:attoparsec": ["lib:attoparsec-internal"]}""",
+        },
+    local_snapshot = "@io_tweag_gazelle_haskell_modules//:snapshot-" + ghc_version + ".yaml",
     packages = [
+        "Cabal",
         "aeson",
         "base",
         "inspection-testing",
@@ -62,13 +83,26 @@ stack_snapshot(
         "tasty-hunit",
         "void",
     ],
-    snapshot = "lts-18.1",
+    setup_deps = {
+        "transformers-compat": ["@stackage//:Cabal"],
+        "hspec-discover": ["@stackage//:Cabal"],
+        "call-stack": ["@stackage//:Cabal"],
+        "HUnit": ["@stackage//:Cabal"],
+        "quickcheck": ["@stackage//:Cabal"],
+        "hspec-expectations": ["@stackage//:Cabal"],
+        "quickcheck-io": ["@stackage//:Cabal"],
+        "tasty-discover": ["@stackage//:Cabal"],
+        "hspec-core": ["@stackage//:Cabal"],
+        "bifunctors": ["@stackage//:Cabal"],
+        "hspec": ["@stackage//:Cabal"],
+    },
 )
 
 load("@rules_haskell//haskell:nixpkgs.bzl", "haskell_register_ghc_nixpkgs")
 
 haskell_register_ghc_nixpkgs(
-    attribute_path = "haskell.compiler.ghc8107",
+    attribute_path =
+        "haskell.compiler.ghc" + ghc_version.replace(".", ""),
     compiler_flags = [
         "-Werror",
         "-Wall",
@@ -77,7 +111,7 @@ haskell_register_ghc_nixpkgs(
         "-Wredundant-constraints",
     ],
     repository = "@nixpkgs",
-    version = "8.10.7",
+    version = ghc_version,
 )
 
 ###############

--- a/himportscan/src/HImportScan/GHC/FakeSettings8_10.hs
+++ b/himportscan/src/HImportScan/GHC/FakeSettings8_10.hs
@@ -1,0 +1,59 @@
+-- Copyright (c) 2020, Shayne Fletcher. All rights reserved.
+-- SPDX-License-Identifier: BSD-3-Clause.
+{-#LANGUAGE CPP #-}
+
+#if __GLASGOW_HASKELL__ == 810
+
+{-# OPTIONS_GHC -Wno-missing-fields #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+-- This file is a single code path copied over from https://hackage.haskell.org/package/ghc-lib-parser-ex-8.10.0.24/docs/src/Language.Haskell.GhclibParserEx.GHC.Settings.Config.html
+-- TODO[GL]: We can get rid of this file once we only support >=9.2, as ParserOpts are much smaller there.
+module HImportScan.GHC.FakeSettings8_10(
+    fakeSettings
+  , fakeLlvmConfig
+  )
+where
+
+import Config
+import DynFlags
+import Fingerprint
+import GHC.Platform
+import ToolSettings
+
+fakeSettings :: Settings
+fakeSettings = Settings
+  { sGhcNameVersion=ghcNameVersion
+  , sFileSettings=fileSettings
+  , sTargetPlatform=platform
+  , sPlatformMisc=platformMisc
+  , sPlatformConstants=platformConstants
+  , sToolSettings=toolSettings
+  }
+  where
+    toolSettings = ToolSettings {
+      toolSettings_opt_P_fingerprint=fingerprint0
+      }
+    fileSettings = FileSettings {}
+    platformMisc = PlatformMisc {}
+    ghcNameVersion =
+      GhcNameVersion{ghcNameVersion_programName="ghc"
+                    ,ghcNameVersion_projectVersion=cProjectVersion
+                    }
+    platform =
+      Platform{
+        platformWordSize=PW8
+      , platformMini=PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}
+      , platformUnregisterised=True
+      }
+    platformConstants =
+      PlatformConstants{pc_DYNAMIC_BY_DEFAULT=False,pc_WORD_SIZE=8}
+
+fakeLlvmConfig :: LlvmConfig
+fakeLlvmConfig = LlvmConfig [] []
+
+#else
+
+module HImportScan.GHC.FakeSettings8_10 where
+
+#endif

--- a/himportscan/src/HImportScan/GHC/FakeSettings9_0.hs
+++ b/himportscan/src/HImportScan/GHC/FakeSettings9_0.hs
@@ -1,0 +1,67 @@
+-- Copyright (c) 2020, Shayne Fletcher. All rights reserved.
+-- SPDX-License-Identifier: BSD-3-Clause.
+{-#LANGUAGE CPP #-}
+
+#if __GLASGOW_HASKELL__ == 900
+
+{-# OPTIONS_GHC -Wno-missing-fields #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+-- This file is a single code path copied over from https://hackage.haskell.org/package/ghc-lib-parser-ex-8.10.0.24/docs/src/Language.Haskell.GhclibParserEx.GHC.Settings.Config.html
+-- TODO[GL]: We can get rid of this file once we only support >=9.2, as ParserOpts are much smaller there.
+module HImportScan.GHC.FakeSettings9_0(
+    fakeSettings
+  , fakeLlvmConfig
+  )
+where
+
+import GHC.Settings.Config
+import GHC.Driver.Session
+import GHC.Utils.Fingerprint
+import GHC.Platform
+import GHC.Settings
+
+fakeSettings :: Settings
+fakeSettings = Settings
+  { sGhcNameVersion=ghcNameVersion
+  , sFileSettings=fileSettings
+  , sTargetPlatform=platform
+  , sPlatformConstants=platformConstants
+  , sPlatformMisc=platformMisc
+  , sToolSettings=toolSettings
+  , sRawSettings=[]
+  }
+  where
+    toolSettings = ToolSettings {
+      toolSettings_opt_P_fingerprint=fingerprint0
+      }
+    fileSettings = FileSettings {}
+    platformMisc = PlatformMisc {}
+    ghcNameVersion =
+      GhcNameVersion{ghcNameVersion_programName="ghc"
+                    ,ghcNameVersion_projectVersion=cProjectVersion
+                    }
+    platform =
+      Platform{
+        platformWordSize=PW8
+      , platformByteOrder = LittleEndian
+      , platformUnregisterised=True
+      , platformHasGnuNonexecStack = False
+      , platformHasIdentDirective = False
+      , platformHasSubsectionsViaSymbols = False
+      , platformIsCrossCompiling = False
+      , platformLeadingUnderscore = False
+      , platformTablesNextToCode = False
+      , platformMini=PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}
+      }
+    platformConstants =
+      PlatformConstants{pc_DYNAMIC_BY_DEFAULT=False,pc_WORD_SIZE=8}
+
+fakeLlvmConfig :: LlvmConfig
+fakeLlvmConfig = LlvmConfig [] []
+
+#else
+
+module HImportScan.GHC.FakeSettings9_0 where
+
+#endif

--- a/himportscan/src/HImportScan/GHC/FakeSettings9_2.hs
+++ b/himportscan/src/HImportScan/GHC/FakeSettings9_2.hs
@@ -1,22 +1,25 @@
 -- Copyright (c) 2020, Shayne Fletcher. All rights reserved.
 -- SPDX-License-Identifier: BSD-3-Clause.
+{-#LANGUAGE CPP #-}
+
+#if __GLASGOW_HASKELL__ == 902
 
 {-# OPTIONS_GHC -Wno-missing-fields #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 -- This file is a single code path copied over from https://hackage.haskell.org/package/ghc-lib-parser-ex-8.10.0.24/docs/src/Language.Haskell.GhclibParserEx.GHC.Settings.Config.html
 -- TODO[GL]: We can get rid of this file once we only support >=9.2, as ParserOpts are much smaller there.
-module HImportScan.GHC.Settings(
+module HImportScan.GHC.FakeSettings9_2(
     fakeSettings
   , fakeLlvmConfig
   )
 where
 
-import Config
-import DynFlags
-import Fingerprint
+import GHC.Settings.Config
+import GHC.Driver.Session
+import GHC.Utils.Fingerprint
 import GHC.Platform
-import ToolSettings
+import GHC.Settings
 
 fakeSettings :: Settings
 fakeSettings = Settings
@@ -24,8 +27,8 @@ fakeSettings = Settings
   , sFileSettings=fileSettings
   , sTargetPlatform=platform
   , sPlatformMisc=platformMisc
-  , sPlatformConstants=platformConstants
   , sToolSettings=toolSettings
+  , sRawSettings=[]
   }
   where
     toolSettings = ToolSettings {
@@ -40,11 +43,23 @@ fakeSettings = Settings
     platform =
       Platform{
         platformWordSize=PW8
-      , platformMini=PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}
+      , platformArchOS=ArchOS {archOS_arch=ArchUnknown, archOS_OS=OSUnknown}
+      , platformByteOrder = LittleEndian
       , platformUnregisterised=True
+      , platformHasGnuNonexecStack = False
+      , platformHasIdentDirective = False
+      , platformHasSubsectionsViaSymbols = False
+      , platformIsCrossCompiling = False
+      , platformLeadingUnderscore = False
+      , platformTablesNextToCode = False
+      , platform_constants = Nothing
       }
-    platformConstants =
-      PlatformConstants{pc_DYNAMIC_BY_DEFAULT=False,pc_WORD_SIZE=8}
 
 fakeLlvmConfig :: LlvmConfig
 fakeLlvmConfig = LlvmConfig [] []
+
+#else
+
+module HImportScan.GHC.FakeSettings9_2 where
+
+#endif

--- a/himportscan/src/HImportScan/GHC8_10.hs
+++ b/himportscan/src/HImportScan/GHC8_10.hs
@@ -1,9 +1,16 @@
--- | A module abstracting the provenance of GHC API names
-module HImportScan.GHC(module X) where
+{-#LANGUAGE CPP #-}
 
+#if __GLASGOW_HASKELL__ == 810
+
+-- | A module abstracting the provenance of GHC API names
+module HImportScan.GHC8_10 (module X, imports, handleParseError) where
+
+import HImportScan.GHC.FakeSettings8_10 as X
+
+import Control.Exception (throwIO)
 import DynFlags as X (DynFlags, defaultDynFlags, xopt_set, xopt_unset)
 import EnumSet as X (empty, fromList)
-import ErrUtils as X (printBagOfErrors)
+import ErrUtils as X (printBagOfErrors, ErrMsg)
 import FastString as X (FastString, mkFastString, bytesFS)
 import GHC as X (runGhc, getSessionDynFlags)
 import GHC.LanguageExtensions as X
@@ -24,8 +31,7 @@ import Lexer as X
   , Token(..)
   , lexer
   , loc
-  , mkParserFlags'
-  , mkPStatePure, unP
+  , unP
   )
 import Module as X (ModuleName, moduleNameString)
 import SrcLoc as X
@@ -40,3 +46,29 @@ import SrcLoc as X
   , unLoc
   )
 import StringBuffer as X (StringBuffer(StringBuffer), stringToStringBuffer)
+import Bag (Bag)
+
+imports ::
+  DynFlags ->
+  StringBuffer ->
+  FilePath ->
+  IO
+    ( Either
+      (Bag ErrMsg)
+      ( [(Maybe FastString, Located ModuleName)],
+        [(Maybe FastString, Located ModuleName)], Located ModuleName
+      )
+    )
+imports dynFlagsWithExtensions sb filePath =
+  getImports dynFlagsWithExtensions sb filePath filePath
+
+handleParseError :: DynFlags -> Bag ErrMsg -> IO a
+handleParseError dynFlagsWithExtensions err = do
+  printBagOfErrors dynFlagsWithExtensions err
+  throwIO (mkSrcErr err)
+
+#else
+
+module HImportScan.GHC8_10 where
+
+#endif

--- a/himportscan/src/HImportScan/GHC9_0.hs
+++ b/himportscan/src/HImportScan/GHC9_0.hs
@@ -1,0 +1,74 @@
+{-#LANGUAGE CPP #-}
+
+#if __GLASGOW_HASKELL__ == 900
+
+-- | A module abstracting the provenance of GHC API names
+module HImportScan.GHC9_0 (module X, imports, handleParseError) where
+
+import HImportScan.GHC.FakeSettings9_0 as X
+
+import Control.Exception (throwIO)
+import GHC.Driver.Session as X (DynFlags, defaultDynFlags, xopt_set, xopt_unset)
+import GHC.Data.EnumSet as X (empty, fromList)
+import GHC.Utils.Error as X (printBagOfErrors, ErrMsg)
+import GHC.Data.FastString as X (FastString, mkFastString, bytesFS)
+import GHC as X (runGhc, getSessionDynFlags)
+import GHC.LanguageExtensions as X
+  (Extension
+    ( ImportQualifiedPost
+    , PackageImports
+    , TemplateHaskell
+    , ImplicitPrelude
+    , PatternSynonyms
+    , ExplicitNamespaces
+    , MagicHash
+    )
+  )
+import GHC.Parser.Header as X (getOptions, getImports)
+import GHC.Driver.Types as X (mkSrcErr)
+import GHC.Parser.Lexer as X
+  ( ParseResult(..)
+  , Token(..)
+  , lexer
+  , loc
+  , unP
+  )
+import GHC.Unit.Module as X (ModuleName, moduleNameString)
+import GHC.Types.SrcLoc as X
+  ( Located
+  , RealSrcLoc
+  , SrcLoc(RealSrcLoc)
+  , getLoc
+  , mkRealSrcLoc
+  , srcLocLine
+  , srcLocCol
+  , srcSpanStart
+  , unLoc
+  )
+import GHC.Data.StringBuffer as X (StringBuffer(StringBuffer), stringToStringBuffer)
+import GHC.Data.Bag (Bag)
+
+imports ::
+  DynFlags ->
+  StringBuffer ->
+  FilePath ->
+  IO
+    ( Either
+      (Bag ErrMsg)
+      ( [(Maybe FastString, Located ModuleName)],
+        [(Maybe FastString, Located ModuleName)], Located ModuleName
+      )
+    )
+imports dynFlagsWithExtensions sb filePath =
+  getImports dynFlagsWithExtensions sb filePath filePath
+
+handleParseError :: DynFlags -> Bag ErrMsg -> IO a
+handleParseError dynFlagsWithExtensions err = do
+  printBagOfErrors dynFlagsWithExtensions err
+  throwIO (mkSrcErr err)
+
+#else
+
+module HImportScan.GHC9_0 where
+
+#endif

--- a/himportscan/src/HImportScan/GHC9_2.hs
+++ b/himportscan/src/HImportScan/GHC9_2.hs
@@ -1,0 +1,87 @@
+{-#LANGUAGE CPP #-}
+
+#if __GLASGOW_HASKELL__ == 902
+
+-- | A module abstracting the provenance of GHC API names
+module HImportScan.GHC9_2 (module X, imports, handleParseError) where
+
+import HImportScan.GHC.FakeSettings9_2 as X
+
+import GHC.Driver.Session as X (DynFlags, defaultDynFlags, xopt_set, xopt_unset)
+import GHC.Data.EnumSet as X (empty, fromList)
+import GHC.Driver.Errors as X (printBagOfErrors)
+import GHC.Data.FastString as X (FastString, mkFastString, bytesFS)
+import GHC as X (runGhc, getSessionDynFlags)
+import GHC.LanguageExtensions as X
+  (Extension
+    ( ImportQualifiedPost
+    , PackageImports
+    , TemplateHaskell
+    , ImplicitPrelude
+    , PatternSynonyms
+    , ExplicitNamespaces
+    , MagicHash
+    )
+  )
+import GHC.Parser.Header as X (getOptions, getImports)
+import GHC.Types.SourceError (mkSrcErr)
+import GHC.Parser.Lexer as X
+  ( ParseResult(..)
+  , ParserOpts
+  , Token(..)
+  , lexer
+  , loc
+  , unP
+  )
+import GHC.Unit.Module as X (ModuleName, moduleNameString)
+import GHC.Types.SrcLoc as X
+  ( Located
+  , RealSrcLoc
+  , SrcLoc(RealSrcLoc)
+  , getLoc
+  , mkRealSrcLoc
+  , srcLocLine
+  , srcLocCol
+  , srcSpanStart
+  , unLoc
+  )
+import GHC.Data.StringBuffer as X (StringBuffer(StringBuffer), stringToStringBuffer)
+import GHC.Driver.Config
+import GHC.Utils.Logger as X
+import GHC.Parser.Errors.Ppr (pprError)
+import Control.Exception (throwIO)
+import GHC.Data.Bag (Bag)
+import GHC.Parser.Errors (PsError)
+
+initOpts :: DynFlags -> ParserOpts
+initOpts = initParserOpts
+
+imports ::
+  DynFlags ->
+  StringBuffer ->
+  FilePath ->
+  IO
+    ( Either
+      (Bag PsError)
+      ( [(Maybe FastString, Located ModuleName)],
+        [(Maybe FastString, Located ModuleName)], Located ModuleName
+      )
+    )
+imports dynFlagsWithExtensions sb filePath =
+  -- [GG] We should never care about the Prelude import,
+  -- since it is always a module from an external library.
+  -- Hence the `False`.
+  getImports (initOpts dynFlagsWithExtensions) False sb filePath filePath
+
+handleParseError :: DynFlags -> Bag PsError -> IO a
+handleParseError dynFlagsWithExtensions err = do
+  logger <- initLogger
+  let errEnvelope = pprError <$> err
+  printBagOfErrors logger dynFlagsWithExtensions errEnvelope
+  throwIO (mkSrcErr errEnvelope)
+
+#else
+
+module HImportScan.GHC9_2 where
+
+#endif

--- a/himportscan/tests/HImportScan/ImportScannerSpec.hs
+++ b/himportscan/tests/HImportScan/ImportScannerSpec.hs
@@ -60,6 +60,9 @@ stripIndentation t =
 testSource :: Text -> Set ModuleImport -> Bool -> Bool -> Text -> IO ()
 testSource = testSourceWithFile "dummy.hs"
 
+stdImport :: Text -> ModuleImport
+stdImport = ModuleImport NormalImport Nothing
+
 testSourceWithFile :: FilePath -> Text -> Set ModuleImport -> Bool -> Bool -> Text -> IO ()
 testSourceWithFile file moduleName importedModules usesTH isBoot contents = do
     fmap NicelyPrinted (scanImports file $ stripIndentation contents)
@@ -73,7 +76,7 @@ testSourceWithFile file moduleName importedModules usesTH isBoot contents = do
 
 spec_scanImports :: Spec
 spec_scanImports = do
-    let m = ModuleImport NormalImport Nothing
+    let m = stdImport
     it "should accept empty files" $
       testSource "Main" [] False False ""
     it "should find an import" $

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,1 +1,1 @@
-import (fetchTarball "https://github.com/nixos/nixpkgs/archive/e544ee88fa4590df75e221e645a03fe157a99e5b.tar.gz")
+import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/refs/tags/22.05.tar.gz")

--- a/snapshot-8.10.7.yaml
+++ b/snapshot-8.10.7.yaml
@@ -1,0 +1,1 @@
+resolver: lts-18.28

--- a/snapshot-9.0.2.yaml
+++ b/snapshot-9.0.2.yaml
@@ -1,0 +1,1 @@
+resolver: lts-19.12

--- a/snapshot-9.2.2.yaml
+++ b/snapshot-9.2.2.yaml
@@ -1,0 +1,7 @@
+resolver: nightly-2022-06-06
+
+packages:
+- git: https://github.com/tweag/cabal
+  commit: 42f04c3f639f10dc3c7981a0c663bfe08ad833cb
+  subdirs:
+  - Cabal

--- a/tests/alternative-deps/WORKSPACE
+++ b/tests/alternative-deps/WORKSPACE
@@ -13,9 +13,9 @@ local_repository(
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "c3c85b886a64010c913a7700b0594dbd4204170b1ec00d1afb5f411868e7c54b",
-    strip_prefix = "rules_haskell-af979957c18e11693d4daba606143a7a362af4b1",
-    urls = ["https://github.com/tweag/rules_haskell/archive/af979957c18e11693d4daba606143a7a362af4b1.zip"],
+    sha256 = "57e55ca74c9dd2710da852c6c9a70fc0274f038ff37216b6c48fd9389bbfbce7",
+    strip_prefix = "rules_haskell-b8ac6c18d26c0011a2464200762e45302a70bbf6",
+    urls = ["https://github.com/tweag/rules_haskell/archive/b8ac6c18d26c0011a2464200762e45302a70bbf6.zip"],
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
@@ -41,6 +41,11 @@ load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 # Haskell dependencies and toolchain
 ######################################
 
+load("@io_tweag_gazelle_haskell_modules//:config_settings/setup.bzl", "config_settings")
+
+config_settings(name = "config_settings")
+
+load("@config_settings//:info.bzl", "ghc_version")
 load("@io_tweag_gazelle_haskell_modules//:defs.bzl", "gazelle_haskell_modules_dependencies")
 
 gazelle_haskell_modules_dependencies(
@@ -49,10 +54,34 @@ gazelle_haskell_modules_dependencies(
 
 stack_snapshot(
     name = "stackage-b",
+    components =
+        None if ghc_version == "8.10.7" else {
+            "attoparsec": [
+                "lib",
+                "lib:attoparsec-internal",
+            ],
+        },
+    components_dependencies =
+        None if ghc_version == "8.10.7" else {
+            "attoparsec": """{"lib:attoparsec": ["lib:attoparsec-internal"]}""",
+        },
+    local_snapshot = "@io_tweag_gazelle_haskell_modules//:snapshot-" + ghc_version + ".yaml",
     packages = [
         "aeson",
     ],
-    snapshot = "lts-18.1",
+    setup_deps = {
+        "transformers-compat": ["@stackage//:Cabal"],
+        "hspec-discover": ["@stackage//:Cabal"],
+        "call-stack": ["@stackage//:Cabal"],
+        "HUnit": ["@stackage//:Cabal"],
+        "quickcheck": ["@stackage//:Cabal"],
+        "hspec-expectations": ["@stackage//:Cabal"],
+        "quickcheck-io": ["@stackage//:Cabal"],
+        "tasty-discover": ["@stackage//:Cabal"],
+        "hspec-core": ["@stackage//:Cabal"],
+        "bifunctors": ["@stackage//:Cabal"],
+        "hspec": ["@stackage//:Cabal"],
+    },
 )
 
 stack_snapshot(
@@ -63,7 +92,9 @@ stack_snapshot(
             "exe:tasty-discover",
         ],
     },
+    local_snapshot = "@io_tweag_gazelle_haskell_modules//:snapshot-" + ghc_version + ".yaml",
     packages = [
+        "Cabal",
         "base",
         "inspection-testing",
         "tasty",
@@ -71,13 +102,26 @@ stack_snapshot(
         "tasty-hunit",
         "void",
     ],
-    snapshot = "lts-18.1",
+    setup_deps = {
+        "transformers-compat": ["@stackage//:Cabal"],
+        "hspec-discover": ["@stackage//:Cabal"],
+        "call-stack": ["@stackage//:Cabal"],
+        "HUnit": ["@stackage//:Cabal"],
+        "quickcheck": ["@stackage//:Cabal"],
+        "hspec-expectations": ["@stackage//:Cabal"],
+        "quickcheck-io": ["@stackage//:Cabal"],
+        "tasty-discover": ["@stackage//:Cabal"],
+        "hspec-core": ["@stackage//:Cabal"],
+        "bifunctors": ["@stackage//:Cabal"],
+        "hspec": ["@stackage//:Cabal"],
+    },
 )
 
 load("@rules_haskell//haskell:nixpkgs.bzl", "haskell_register_ghc_nixpkgs")
 
 haskell_register_ghc_nixpkgs(
-    attribute_path = "haskell.compiler.ghc8107",
+    attribute_path =
+        "haskell.compiler.ghc" + ghc_version.replace(".", ""),
     compiler_flags = [
         "-Werror",
         "-Wall",
@@ -86,7 +130,7 @@ haskell_register_ghc_nixpkgs(
         "-Wredundant-constraints",
     ],
     repository = "@nixpkgs",
-    version = "8.10.7",
+    version = ghc_version,
 )
 
 ###############

--- a/tests/alternative-deps/snapshot.yaml
+++ b/tests/alternative-deps/snapshot.yaml
@@ -1,0 +1,1 @@
+../../snapshot.yaml


### PR DESCRIPTION
Add several GHC interface files in HImport scan and several snapshot.yaml
to allow the user to use its favourite ghc version using --config=ghc_X_X_X.
The three versions of GHC in nixpks 22.05 (version 8.10.7, 9,.0.2 and 9.2.2)
are supported now.
For version 9.2.2, due to a bug in version 3.6.3.0 of cabal, one has to use
a custom version of cabal.