### PR TITLE
Commenting on imports purpose

### DIFF
--- a/gazelle_haskell_modules/dependency_resolution.go
+++ b/gazelle_haskell_modules/dependency_resolution.go
@@ -23,7 +23,6 @@ import (
 // from deps that uses the modules attribute is moved to narrowed_deps.
 //
 func setNonHaskellModuleDeps(
-	c *Config,
 	repoRoot string,
 	ix *resolve.RuleIndex,
 	r *rule.Rule,

--- a/gazelle_haskell_modules/lang.go
+++ b/gazelle_haskell_modules/lang.go
@@ -42,25 +42,7 @@ func (*gazelleHaskellModulesLang) KnownDirectives() []string {
 type Config struct {
 }
 
-func (*gazelleHaskellModulesLang) Configure(c *config.Config, rel string, f *rule.File) {
-	if f == nil {
-		return
-	}
-
-	m, ok := c.Exts[gazelleHaskellModulesName]
-	var extraConfig Config
-	if ok {
-		extraConfig = m.(Config)
-	} else {
-		extraConfig = Config{}
-	}
-
-	for _, directive := range f.Directives {
-		switch directive.Key {
-		}
-	}
-	c.Exts[gazelleHaskellModulesName] = extraConfig
-}
+func (*gazelleHaskellModulesLang) Configure(c *config.Config, rel string, f *rule.File) {}
 
 var haskellAttrInfo = rule.KindInfo{
 	MatchAttrs:    []string{},
@@ -170,9 +152,8 @@ func (*gazelleHaskellModulesLang) Imports(c *config.Config, r *rule.Rule, f *rul
 func (*gazelleHaskellModulesLang) Embeds(r *rule.Rule, from label.Label) []label.Label { return nil }
 
 func (*gazelleHaskellModulesLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
-	hmc := c.Exts[gazelleHaskellModulesName].(Config)
 	if isNonHaskellModule(r.Kind()) {
-		setNonHaskellModuleDeps(&hmc, c.RepoRoot, ix, r, imports.(*HRuleImportData), from)
+		setNonHaskellModuleDeps(c.RepoRoot, ix, r, imports.(*HRuleImportData), from)
 	} else {
 		setHaskellModuleDeps(ix, r, imports.(*HModuleImportData), from)
 	}
@@ -191,8 +172,7 @@ func (*gazelleHaskellModulesLang) GenerateRules(args language.GenerateArgs) lang
 
 	setVisibilities(args.File, generateResult.Gen)
 
-	c := args.Config.Exts[gazelleHaskellModulesName].(Config)
-	return addNonHaskellModuleRules(&c, args.Dir, args.Config.RepoName, args.File.Pkg, generateResult, args.File.Rules)
+	return addNonHaskellModuleRules(args.Dir, args.Config.RepoName, args.File.Pkg, generateResult, args.File.Rules)
 }
 
 func (*gazelleHaskellModulesLang) Fix(c *config.Config, f *rule.File) {

--- a/gazelle_haskell_modules/rule_generation.go
+++ b/gazelle_haskell_modules/rule_generation.go
@@ -225,7 +225,6 @@ func infoToRules(pkgRoot string, ruleInfos []*RuleInfo) language.GenerateResult 
 }
 
 func addNonHaskellModuleRules(
-	c *Config,
 	pkgRoot string,
 	repo string,
 	pkg string,


### PR DESCRIPTION
This deletes the references to `Config` whenever it is possible, since `Config` is `struct {}` (the unit type, written in Golang). Also completely erases the configuration phase, since it was a quite complex function to construct an empty structure.

Adds some comments on the fields added to the RuleIndex by the Imports phase, and why those fields are useful to "`Resolve`" the rules.