### PR TITLE
Use stack from nixpkgs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,5 @@
+build --host_platform=@rules_nixpkgs_core//platforms:host
+
 # Remote Cache Configuration
 build:remote-cache --bes_results_url=https://app.buildbuddy.io/invocation/
 build:remote-cache --bes_backend=grpcs://remote.buildbuddy.io

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Test for buildifier suggestions
         uses: tweag/run-nix-shell@v0
         with:
-          run: bazel run //:buildifier-diff
+          run: bazel test //:buildifier-test
 
   all_ci_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -42,7 +42,6 @@ jobs:
       - name: Configure
         run: |
           cat >>.bazelrc.local <<EOF
-          build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
           build --config=remote-cache
           build --repository_cache=~/repo-cache/
           EOF

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,12 +1,13 @@
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
 
 exports_files(["defs.bzl"])
 
-buildifier(
-    name = "buildifier-diff",
+buildifier_test(
+    name = "buildifier-test",
     buildifier = "@buildifier//:buildifier",
     diff_command = "diff -u",
-    mode = "diff",
+    no_sandbox = True,
+    workspace = ":WORKSPACE",
 )
 
 buildifier(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,10 +2,16 @@ load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "bui
 
 exports_files(["defs.bzl"])
 
+_lint_warnings = [
+    "-module-docstring",  # disable module docstrings
+]
+
 buildifier_test(
     name = "buildifier-test",
     buildifier = "@buildifier//:buildifier",
     diff_command = "diff -u",
+    lint_mode = "warn",
+    lint_warnings = _lint_warnings,
     no_sandbox = True,
     workspace = ":WORKSPACE",
 )
@@ -13,5 +19,6 @@ buildifier_test(
 buildifier(
     name = "buildifier",
     buildifier = "@buildifier//:buildifier",
-    lint_mode = "warn",
+    lint_mode = "fix",
+    lint_warnings = _lint_warnings,
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,11 +4,13 @@ exports_files(["defs.bzl"])
 
 buildifier(
     name = "buildifier-diff",
+    buildifier = "@buildifier//:buildifier",
     diff_command = "diff -u",
     mode = "diff",
 )
 
 buildifier(
     name = "buildifier",
+    buildifier = "@buildifier//:buildifier",
     lint_mode = "warn",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -65,6 +65,7 @@ rules_haskell_dependencies()
 load(
     "@rules_nixpkgs_core//:nixpkgs.bzl",
     "nixpkgs_local_repository",
+    "nixpkgs_package",
 )
 load(
     "@rules_nixpkgs_python//:python.bzl",
@@ -78,7 +79,15 @@ nixpkgs_local_repository(
 
 nixpkgs_python_configure(repository = "@nixpkgs")
 
-load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
+nixpkgs_package(
+    name = "stack",
+    attribute_path = "stack",
+    repository = "@nixpkgs",
+)
+
+load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot", "use_stack")
+
+use_stack("@stack//:bin/stack")
 
 ######################################
 # Haskell dependencies and toolchain

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -204,9 +204,14 @@ gazelle_dependencies()
 # Buildifier preamble
 #######################
 
-http_archive(
-    name = "com_github_bazelbuild_buildtools",
-    sha256 = "53119397bbce1cd7e4c590e117dcda343c2086199de62932106c80733526c261",
-    strip_prefix = "buildtools-8.2.1",
-    url = "https://github.com/bazelbuild/buildtools/archive/refs/tags/v8.2.1.tar.gz",
+nixpkgs_package(
+    name = "buildifier",
+    attribute_path = "buildifier",
+    build_file_content = """\
+filegroup(
+  name = "buildifier",
+  srcs = ["bin/buildifier"],
+  visibility = ["//visibility:public"]
+)""",
+    repository = "@nixpkgs",
 )

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -53,6 +53,7 @@ rules_haskell_dependencies()
 load(
     "@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
     "nixpkgs_local_repository",
+    "nixpkgs_package",
     "nixpkgs_python_configure",
 )
 
@@ -63,7 +64,15 @@ nixpkgs_local_repository(
 
 nixpkgs_python_configure(repository = "@nixpkgs")
 
-load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
+nixpkgs_package(
+    name = "stack",
+    attribute_path = "stack",
+    repository = "@nixpkgs",
+)
+
+load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot", "use_stack")
+
+use_stack("@stack//:bin/stack")
 
 ######################################
 # Haskell dependencies and toolchain

--- a/tests/alternative-deps/WORKSPACE
+++ b/tests/alternative-deps/WORKSPACE
@@ -53,6 +53,7 @@ rules_haskell_dependencies()
 load(
     "@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
     "nixpkgs_local_repository",
+    "nixpkgs_package",
     "nixpkgs_python_configure",
 )
 
@@ -63,7 +64,15 @@ nixpkgs_local_repository(
 
 nixpkgs_python_configure(repository = "@nixpkgs")
 
-load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
+nixpkgs_package(
+    name = "stack",
+    attribute_path = "stack",
+    repository = "@nixpkgs",
+)
+
+load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot", "use_stack")
+
+use_stack("@stack//:bin/stack")
 
 ######################################
 # Haskell dependencies and toolchain


### PR DESCRIPTION
This uses a more recent stack version (currently 2.15.7) which fixes a problem updating
packages from hackage with older versions using Cabal < 3.10.2.0:

```
Selected mirror https://hackage.haskell.org/
Downloading root
<repo>/root.json does not have enough signatures signed with the appropriate keys
```

See https://github.com/haskell/cabal/issues/11111

Related: https://github.com/tweag/rules_haskell/pull/2320
